### PR TITLE
Add manual workflow dispatch trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: ci
 on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or ref to run against (defaults to current branch)'
+        required: false
+        default: ''
+
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
## Summary
• Add workflow_dispatch trigger to CI workflow for manual execution

## Test plan
- [ ] Verify workflow can be triggered manually from GitHub Actions tab
- [ ] Confirm ref parameter works correctly