### PR TITLE
Use compatible CDK version range

### DIFF
--- a/cdk/requirements.txt
+++ b/cdk/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.1025.0
+aws-cdk-lib>=2,<3
 constructs>=10.0.0


### PR DESCRIPTION
Set CDK version to use compatible range instead of exact version for better flexibility